### PR TITLE
Fix out of bounds write

### DIFF
--- a/libgdsto3d/gdsobjectlist.cpp
+++ b/libgdsto3d/gdsobjectlist.cpp
@@ -71,9 +71,10 @@ GDSObject *GDSObjectList::SearchObject(const char *Name, const char *gdsName)
 	
 	for (unsigned int i = 0; i<objects.size(); i++)
 	{
-		char *GDSName = new char [strlen(objects[i]->GetName())];
-		strncpy(GDSName,Name, strlen(objects[i]->GetName()));
-		GDSName[strlen(objects[i]->GetName())] = '\0';
+		size_t namelen = strlen(objects[i]->GetName());
+		char *GDSName = new char [namelen+1];
+		strncpy(GDSName,Name, namelen);
+		GDSName[namelen] = '\0';
 		if(gdsName == NULL && objects[i]->GetGDSName()!= NULL 
 			&& strcmp(Name, objects[i]->GetGDSName()) == 0 
            && strcmp(GDSName, objects[i]->GetName()) == 0) {


### PR DESCRIPTION
The allocation here is for the length of the string, but the
zero byte is being written one byte past the end of the string.
In unlucky situtations this can override the malloc header of
the subsequent allocation causing crashes.