### PR TITLE
linux: Specify -std=c++11 when building

### DIFF
--- a/linux/Makefile
+++ b/linux/Makefile
@@ -1,6 +1,6 @@
 # Flags
 CXX=g++
-CXXFLAGS=-c -w -O1 -I ../math/ -I ../gdsoglviewer/ -I ../libgdsto3d/
+CXXFLAGS=-std=c++11 -c -w -O1 -I ../math/ -I ../gdsoglviewer/ -I ../libgdsto3d/
 LDFLAGS=-L/usr/X11R6/lib64/ -lX11 -lGL -static-libgcc -static-libstdc++ -fopenmp
 # Static linking of stdc++ available starting at GCC 4.5
 

--- a/linux/Makefile
+++ b/linux/Makefile
@@ -1,6 +1,6 @@
 # Flags
-CC=g++
-CFLAGS=-c -w -O1 -I ../math/ -I ../gdsoglviewer/ -I ../libgdsto3d/
+CXX=g++
+CXXFLAGS=-c -w -O1 -I ../math/ -I ../gdsoglviewer/ -I ../libgdsto3d/
 LDFLAGS=-L/usr/X11R6/lib64/ -lX11 -lGL -static-libgcc -static-libstdc++ -fopenmp
 # Static linking of stdc++ available starting at GCC 4.5
 
@@ -26,10 +26,10 @@ EXECUTABLE=./GDS3D
 all: $(SOURCES) $(HEADERS) $(EXECUTABLE)
 	
 $(EXECUTABLE): $(OBJECTS) 
-	$(CC) $(OBJECTS) -o $@ $(LDFLAGS)
+	$(CXX) $(OBJECTS) -o $@ $(LDFLAGS)
 
 .cpp.o:
-	$(CC) $(CFLAGS) $< -o $@
+	$(CXX) $(CXXFLAGS) $< -o $@
 
 clean: # Clean object files
 	rm -f $(OBJECTS) 


### PR DESCRIPTION
GCC 11 updated its default c++ standard from 11 to 17 which caused issues related to std::byte among other things.

I made it build by specifying -std=c++11.

I also renamed CC/CFLAGS to CXX/CXXFLAGS to be more specific that c++ is being compiled.