### PR TITLE
Retina support on macOS

### DIFF
--- a/mac/OpenGLView.mm
+++ b/mac/OpenGLView.mm
@@ -214,8 +214,9 @@ OpenGLView *view_gl; // Us this to access the Cocoa stuff
 
 - (void) resizeView
 {
-    int newHeight = self.window.initialFirstResponder.bounds.size.height;
-    int newWidth  = self.window.initialFirstResponder.bounds.size.width;
+    NSRect backingBounds = [self convertRectToBacking:[self bounds]];
+    int newHeight = backingBounds.size.height;
+    int newWidth  = backingBounds.size.width;
     
     if(viewWidth==newWidth && viewHeight==newHeight) // This function is called every frame...
         return;


### PR DESCRIPTION
now uses whole viewport and not just bottom left:

current:
<img width="400" alt="5A6BD76C-BC40-45DE-AD07-0B91CC0F04F8-2294-00008C403383B127" src="https://user-images.githubusercontent.com/96857/145180508-6c47338a-31e0-42e3-a14e-bfc45e9eb2b0.png">

after this change:
<img width="400" alt="C2204595-FF6A-49C5-B5AF-DAADFF71A5EF-2294-00008C42A41D7423" src="https://user-images.githubusercontent.com/96857/145180544-7eb21c0c-fefd-44c5-aef4-b32c94c922d5.png">

see https://developer.apple.com/library/archive/documentation/GraphicsImaging/Conceptual/OpenGL-MacProgGuide/EnablingOpenGLforHighResolution/EnablingOpenGLforHighResolution.html
