### PR TITLE
fix "error: reference to 'byte' is ambiguous"

### DIFF
--- a/libgdsto3d/gds_globals.h
+++ b/libgdsto3d/gds_globals.h
@@ -112,13 +112,13 @@ typedef enum gds_element_type{
 
 /* Two consecutive zero bytes are a null word */
 
-typedef unsigned char byte;
+typedef unsigned char Byte;
 
 typedef struct gds_header{
 	short RecordLength;
-	byte RecordType;
-	byte DataType;
-	byte *Data;
+	Byte RecordType;
+	Byte DataType;
+	Byte *Data;
 }gds_header;
 
 /* A word consists of 16 bits, numbered from 0 to 15, left to right. */

--- a/libgdsto3d/gdsparse.cpp
+++ b/libgdsto3d/gdsparse.cpp
@@ -127,7 +127,7 @@ void GDSParse::Reload()
 
 bool GDSParse::ParseFile(char *topcell)
 {
-	byte recordtype, datatype;
+	Byte recordtype, datatype;
 	char *tempstr;
 	//struct ProcessLayer *layer = NULL;
     
@@ -1086,7 +1086,7 @@ _currentstrans=0; //Oh yeah!
 
 short GDSParse::GetBitArray()
 {
-	byte byte1;
+	Byte byte1;
 
 	fread(&byte1, 1, 1, _iptr);
 	fread(&byte1, 1, 1, _iptr);
@@ -1097,8 +1097,8 @@ short GDSParse::GetBitArray()
 
 double GDSParse::GetEightByteReal()
 {
-	byte value;
-	byte b8, b2, b3, b4, b5, b6, b7;
+	Byte value;
+	Byte b8, b2, b3, b4, b5, b6, b7;
 	double sign=1.0;
 	double exponent;
 	double mant;


### PR DESCRIPTION
Tested it on Fedora 39 / gcc version 13.2.1 20231205 (Red Hat 13.2.1-6) (GCC)