### PR TITLE
Fix SIGSEGV on missing font, add error message

### DIFF
--- a/linux/main.cpp
+++ b/linux/main.cpp
@@ -496,7 +496,17 @@ int Wm_X11::main(int argc, char *argv[])
 	font = glGenLists( 256 );
 
 	fixed = XLoadQueryFont(
-		dpy, "-misc-fixed-medium-r-*-*-20-*-*-*-*-*-*-*" );
+		dpy, "-*-fixed-*-*-*-*-*-*-*-*-*-*-*-*" );
+
+	if ( fixed == NULL )
+	{
+		fprintf( stderr, "XLoadQueryFont failed\n" );
+		glXDestroyContext( dpy, ctx );
+		XDestroyWindow( dpy, win );
+		XCloseDisplay( dpy );
+        XFree(vi);
+		return ( 1 );
+	}
 
 	null_cursor = XCreateGlyphCursor(
 		dpy, fixed->fid, fixed->fid, ' ', ' ', &black, &black );


### PR DESCRIPTION
The font name in linux/main.cpp was missing on my system, resulting in a SIGSEGV upon startup. I changed a few fields to wildcards to have a better chance of actually returning a font and added a null check if it still didn't work.